### PR TITLE
Add error handling for failed evalulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ qli --app myapp.qvf meta
 
 Evaluate expressions. Note the "by" keyword. The format is <expressions> by <dimensions>.
 ```bash
-qli --app myapp.qvf evaluate "sum(Z)" by X Y
+qli --app myapp.qvf eval "sum(Z)" by X Y
 ```
 
 Specify what Qlik Associative Engine to use with the --engine parameter

--- a/internal/eval.go
+++ b/internal/eval.go
@@ -3,9 +3,11 @@ package internal
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+
 	tm "github.com/buger/goterm"
 	"github.com/qlik-oss/enigma-go"
-	"strings"
 )
 
 func Eval(ctx context.Context, doc *enigma.Doc, args []string) {
@@ -25,7 +27,19 @@ func Eval(ctx context.Context, doc *enigma.Doc, args []string) {
 	})
 	fmt.Println("---------- " + strings.Join(args, " ") + " ----------")
 	grid := tm.NewTable(0, 10, 3, ' ', 0)
-	layout, _ := object.GetLayout(ctx)
+	layout, err := object.GetLayout(ctx)
+
+	if err != nil {
+		fmt.Println("Failed to get hypercube layout: ", err)
+		os.Exit(1)
+	}
+
+	// If the dimension info contains an error element the expression failed to evaluate
+	if layout.HyperCube.DimensionInfo[0].Error != nil {
+		fmt.Println("Failed to evaluate expression with error code:", layout.HyperCube.DimensionInfo[0].Error.ErrorCode)
+		os.Exit(1)
+	}
+
 	fmt.Print(grid, strings.Join(dims, "\t"))
 	fmt.Print(grid, "\t")
 	fmt.Println(grid, strings.Join(measures, "\t"))


### PR DESCRIPTION
Earlier there was no error handling when failing to evaluate an expression, and the documentation was also incorrect.