### PR TITLE
eval: Handle when iterating over all dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,22 @@ Print the metadata with reload
 qli --app myapp.qvf meta
 ```
 
-Evaluate expressions. Note the "by" keyword. The format is <expressions> by <dimensions>.
+Evaluate expressions. Note the "by" keyword. The format is `<expressions> by <dimensions>`.
+
 ```bash
 qli --app myapp.qvf eval "sum(Z)" by X Y
+```
+
+or iterate over all dimensions:
+
+```bash
+qli --app myapp.qvf eval "sum(Z)" by "*"
+```
+
+The `eval` command can also be used for calculated dimensions:
+
+```bash
+qli --app myapp.qvf eval "=A+B+C"
 ```
 
 Specify what Qlik Associative Engine to use with the --engine parameter

--- a/buildtohomebin
+++ b/buildtohomebin
@@ -1,2 +1,6 @@
 #!/usr/bin/env bash
+
+# Execute in script directory
+cd "$(dirname "$0")"
+
 go build -o ~/bin/qli.exe main.go

--- a/internal/eval.go
+++ b/internal/eval.go
@@ -40,9 +40,10 @@ func Eval(ctx context.Context, doc *enigma.Doc, args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Print(grid, strings.Join(dims, "\t"))
-	fmt.Print(grid, "\t")
-	fmt.Println(grid, strings.Join(measures, "\t"))
+	fmt.Fprintf(grid, strings.Join(dims, "\t"))
+	fmt.Fprintf(grid, "\t")
+	fmt.Fprintf(grid, strings.Join(measures, "\t"))
+	fmt.Fprintf(grid, "\n")
 	// Get hypercube layout
 	for _, page := range layout.HyperCube.DataPages {
 		for _, row := range page.Matrix {

--- a/internal/eval.go
+++ b/internal/eval.go
@@ -35,7 +35,7 @@ func Eval(ctx context.Context, doc *enigma.Doc, args []string) {
 	}
 
 	// If the dimension info contains an error element the expression failed to evaluate
-	if layout.HyperCube.DimensionInfo[0].Error != nil {
+	if len(layout.HyperCube.DimensionInfo) != 0 && layout.HyperCube.DimensionInfo[0].Error != nil {
 		fmt.Println("Failed to evaluate expression with error code:", layout.HyperCube.DimensionInfo[0].Error.ErrorCode)
 		os.Exit(1)
 	}
@@ -67,7 +67,10 @@ func argumentsToMeasuresAndDims(args []string) ([]string, []string) {
 	)
 	for _, arg := range args {
 		if arg != "by" {
-			tempArray = append(tempArray, arg)
+			// Skip appending dimension if iterating over all dimensions
+			if arg != "*" {
+				tempArray = append(tempArray, arg)
+			}
 		} else {
 			//The first set of arguments are treated as measures when we find the "by" keyword
 			//Switch to adding dimensions

--- a/internal/eval_test.go
+++ b/internal/eval_test.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"github.com/magiconair/properties/assert"
 	"testing"
+
+	"github.com/magiconair/properties/assert"
 )
 
 func TestArgumentsToMeasuresAndDims1(t *testing.T) {
@@ -18,4 +19,11 @@ func TestArgumentsToMeasuresAndDims2(t *testing.T) {
 	assert.Equal(t, len(measures), 0)
 	assert.Equal(t, dims[0], "dim1")
 	assert.Equal(t, dims[1], "dim2")
+}
+
+func TestArgumentsToMeasuresAndDimsStar(t *testing.T) {
+	measures, dims := argumentsToMeasuresAndDims([]string{"measure1", "measure2", "by", "*"})
+	assert.Equal(t, measures[0], "measure1")
+	assert.Equal(t, measures[1], "measure2")
+	assert.Equal(t, dims, []string{})
 }


### PR DESCRIPTION
It's now possible to evaluate an expression regardless of dimension using the `*`. Also added some more examples to the readme.